### PR TITLE
mido_backend: Fix _find_port() when passing get_devices() name

### DIFF
--- a/alsa_midi/mido_backend.py
+++ b/alsa_midi/mido_backend.py
@@ -95,7 +95,7 @@ def get_devices(*args, **kwargs):
 def _find_port(ports: List[alsa_midi.PortInfo], name: str) -> alsa_midi.PortInfo:
     try:
         addr = alsa_midi.Address(name)
-    except ValueError:
+    except (ValueError, alsa_midi.exceptions.ALSAError):
         addr = None
 
     if addr is not None:


### PR DESCRIPTION
* alsa_midi.Address(name) when "name" is something like "FLUID Synth (327406):Synth input port (327406:0) 128:0" will brutally fail causing the following exception:
* alsa_midi.exceptions.ALSAError: Invalid argument
* Also catch alsa_midi.exceptions.ALSAError to let the next code execute (correctly matching the port)

Change-Id: Ieadd1f74bf888fa8b07e84d09d013afbb2f39880
